### PR TITLE
Add support for YAML loading

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,8 @@ simple_salesforce = "*"
 click = "*"
 tabulate = "*"
 click-aliases = "*"
-
+setupext-janitor = "*"
+pyyaml = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "85e737fba847c5d19ecf5c09702f480821f42647b79732e31109ba59c0397fee"
+            "sha256": "48d090ec9b8487392fe75a62d871d1d84e592bf3ff5f2a5e1424de3aebdfc4b9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,10 +25,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "cffi": {
             "hashes": [
@@ -127,6 +127,25 @@
             ],
             "version": "==19.0.0"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "index": "pypi",
+            "version": "==5.1.2"
+        },
         "requests": {
             "extras": [
                 "security"
@@ -136,6 +155,14 @@
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "version": "==2.22.0"
+        },
+        "setupext-janitor": {
+            "hashes": [
+                "sha256:cb7c071785e1555bef5949cd322f37c2101ea475c8668c6119a697b8cde51966",
+                "sha256:fee46795d797dbd25be8aaf450d0a0d9d3ed248070fe706ecf8cd9f740f49e35"
+            ],
+            "index": "pypi",
+            "version": "==1.1.1"
         },
         "simple-salesforce": {
             "hashes": [
@@ -160,10 +187,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
-                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+                "sha256:2f3eadfea5d92bc7899e75b5968410b749a054b492d5a6379c1344a1481bc2cb",
+                "sha256:9c6c593cb28f52075016307fc26b0a0f8e82bc7d1ff19aaaa959b91710a56c47"
             ],
-            "version": "==1.25.3"
+            "version": "==1.25.5"
         }
     },
     "develop": {
@@ -198,11 +225,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:23d3d873e008a513952355379d93cbcab874c58f4f034ff657c7a87422fa64e8",
-                "sha256:80d2de76188eabfbfcf27e6a37342c2827801e59c4cc14b0371c56fed43820e3"
+                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
+                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.19"
+            "version": "==0.23"
         },
         "mccabe": {
             "hashes": [
@@ -228,17 +255,17 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
-                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
             ],
-            "version": "==19.1"
+            "version": "==19.2"
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "py": {
             "hashes": [
@@ -270,11 +297,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:95b1f6db806e5b1b5b443efeb58984c24945508f93a866c1719e1a507a957d7c",
-                "sha256:c3d5020755f70c82eceda3feaf556af9a341334414a8eca521a18f463bcead88"
+                "sha256:95d13143cc14174ca1a01ec68e84d76ba5d9d493ac02716fd9706c949a505210",
+                "sha256:b78fe2881323bd44fd9bd76e5317173d4316577e7b1cddebae9136a4495ec865"
             ],
             "index": "pypi",
-            "version": "==5.1.1"
+            "version": "==5.1.2"
         },
         "six": {
             "hashes": [

--- a/salesforce_timecard/cli.py
+++ b/salesforce_timecard/cli.py
@@ -4,6 +4,7 @@ import sys
 import re
 import logging
 import json
+import yaml
 from functools import wraps
 import click
 from click_aliases import ClickAliasedGroup
@@ -23,168 +24,7 @@ logger.setLevel(logging.INFO)
 te = TimecardEntry()
 
 
-def catch_exceptions(func):
-    @wraps(func)
-    def decorated(*args, **kwargs):
-        """
-        Invokes ``func``, catches expected errors, prints the error message and
-        exits sceptre with a non-zero exit code.
-        """
-        try:
-            return func(*args, **kwargs)
-        except KeyboardInterrupt:
-            click.echo(" bye bye")
-        except:
-            if len(str(sys.exc_info()[1])) > 0:
-                logger.error(sys.exc_info()[1])
-                sys.exit(1)
-
-    return decorated
-
-
-@click.group(cls=ClickAliasedGroup)
-@click.version_option(prog_name=__description__, version=__version__)
-@click.option("-v", "--verbose", is_flag=True, help="verbose")
-@click.option(
-    "-s", "--startday", default=te.start.strftime("%Y-%m-%d"), help="Start day")
-@click.option(
-    "-e", "--endday", default=te.end.strftime("%Y-%m-%d"), help="End day")
-@click.option(
-    "--week", default="", help="relative week interval e.g.: -1")    
-@click.pass_context
-def cli(ctx, verbose, startday, endday, week):  # pragma: no cover
-
-    regex = r"^([2][0]\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$"
-    if not re.match(regex, startday):
-        click.echo("INVALID start date - please use YYYY-MM-DD format")
-        sys.exit(1)
-
-    if not re.match(regex, endday):
-        click.echo("INVALID end date - please use YYYY-MM-DD format")
-        sys.exit(1)    
-
-    if week != "":
-        day = date.today().strftime("%Y-%m-%d")
-        dt = datetime.strptime(day, "%Y-%m-%d")
-        _startday = dt - timedelta(days=dt.weekday()) + timedelta(weeks=int(week))
-        _endday = _startday + timedelta(days=6)
-        startday = _startday.strftime("%Y-%m-%d")
-        endday = _endday.strftime("%Y-%m-%d")
-
-    if verbose:
-        logger.setLevel(logging.DEBUG)
-        logger.debug("enabling DEBUG mode")
-    ctx.obj = {
-        "options": {},
-        "startday": startday,
-        "endday": endday
-    }
-
-
-@cli.command(name="delete",aliases=["d", "del", "rm", "remove"])
-@click.argument("timecard", required=False)
-@click.pass_context
-@catch_exceptions
-def delete(ctx, timecard):
-   
-    if not timecard:
-        rs = te.list_timecard(False, ctx.obj["startday"], ctx.obj["endday"])
-        i = 0
-        nice_tn = []
-        click.echo("Please choose which timecard:")
-        for timecard_rs in rs:
-            click.echo("[{}] {} - {}".format(i,
-                                             timecard_rs["Name"],
-                                             timecard_rs.get(
-                                                 "pse__Project_Name__c", "")
-                                             )
-                       )
-            nice_tn.append(
-                {"Id": timecard_rs["Id"], "Name": timecard_rs["Name"]})
-            i += 1
-        select_tmc = input("Selection: ")
-        timecard_id = nice_tn[int(select_tmc)]["Id"]
-        timecard_name = nice_tn[int(select_tmc)]["Name"]
-    else:
-        timecard_id = te.get_timecard_id(timecard)
-        timecard_name = timecard
-
-    if click.confirm(
-            "Do you want to delete the timecard: {} {}?".format(
-                timecard_name,
-                timecard_rs.get("pse__Project_Name__c", "")
-            ),
-            abort=True):
-        te.delete_time_entry(timecard_id)
-        logger.info("timecard {} deleted".format(timecard_name))
-
-
-@cli.command(name="submit", aliases=["s", "send"])
-@click.option(
-    "-f", "--force", default=False, is_flag=True, help="confirm all question")    
-
-@click.pass_context
-@catch_exceptions
-def submit(ctx, force):
-    rs = te.list_timecard(False, ctx.obj["startday"], ctx.obj["endday"])
-    tc_ids = []
-    for timecard_rs in rs:
-        click.echo("{} - {}".format(timecard_rs["Name"],
-                                    timecard_rs.get(
-                                            "pse__Project_Name__c", "")
-                                        )
-                )
-        tc_ids.append(timecard_rs)
-
-    if force == False:
-            click.confirm("Do you want to submit all timecard ?", default=True, abort=True)
-            click.echo()
-
-    for tc in tc_ids:
-        te.submit_time_entry(tc["Id"])
-        logger.info("timecard {} submitted".format(tc["Name"]))        
-
-
-@cli.command(name="list", aliases=["ls", "lst", "l"])
-@click.option("--details/--no-details", default=False)
-@click.option(
-    "--style",
-    type=click.Choice(["plain", "simple", "github", "grid", "fancy_grid", "pipe", "orgtbl", "jira", "presto", "json"]),
-    default="grid",
-    help="table style")
-@click.pass_context
-@catch_exceptions
-def list(ctx, details, style):
-    rs = te.list_timecard(details, ctx.obj["startday"], ctx.obj["endday"])
-    if style == "json":
-        click.echo(json.dumps(rs, indent=4))
-    else:
-        hc = HoursCounter(rs)
-        click.echo(tabulate(hc.report, headers="keys", tablefmt=style, stralign="center", ))
-        
-
-
-@cli.command(name="add", aliases=["a", "ad"])
-@click.option(
-    "-p", "--project", default="", help="Project Name")
-@click.option(
-    "-n", "--notes", default="Business as usual", help="Notes to add")
-@click.option(
-    "-t", "--hours", default=0, help="hour/s to add")
-@click.option(
-    "--weekday",
-    type=click.Choice(["Monday", "Tuesday", "Wednesday",
-                       "Thursday", "Friday", "Saturday", "Sunday"]),
-    default=date.today().strftime("%A"),
-    help="Weekday to add")
-@click.option(
-    "-w",
-    type=click.Choice(["", "1", "2", "3", "4", "5", "6", "7"]),
-    default="",
-    help="INT Weekday to add")
-@click.pass_context
-@catch_exceptions
-def add(ctx, project, notes, hours, weekday, w):
+def process_row(ctx, project, notes, hours, weekday, w, file):
     assignment_id = None
     active_assignment = te.get_assignments_active()
     for _, assign in active_assignment.items():
@@ -243,3 +83,182 @@ def add(ctx, project, notes, hours, weekday, w):
     te.add_time_entry(assignment_id, day_n_in, hours_in, notes)
     logger.info("Time card added")
 
+
+def catch_exceptions(func):
+    @wraps(func)
+    def decorated(*args, **kwargs):
+        """
+        Invokes ``func``, catches expected errors, prints the error message and
+        exits sceptre with a non-zero exit code.
+        """
+        try:
+            return func(*args, **kwargs)
+        except KeyboardInterrupt:
+            click.echo(" bye bye")
+        except:
+            if len(str(sys.exc_info()[1])) > 0:
+                logger.error(sys.exc_info()[1])
+                sys.exit(1)
+
+    return decorated
+
+
+@click.group(cls=ClickAliasedGroup)
+@click.version_option(prog_name=__description__, version=__version__)
+@click.option("-v", "--verbose", is_flag=True, help="verbose")
+@click.option(
+    "-s", "--startday", default=te.start.strftime("%Y-%m-%d"), help="Start day")
+@click.option(
+    "-e", "--endday", default=te.end.strftime("%Y-%m-%d"), help="End day")
+@click.option(
+    "--week", default="", help="relative week interval e.g.: -1")
+@click.pass_context
+def cli(ctx, verbose, startday, endday, week):  # pragma: no cover
+
+    regex = r"^([2][0]\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$"
+    if not re.match(regex, startday):
+        click.echo("INVALID start date - please use YYYY-MM-DD format")
+        sys.exit(1)
+
+    if not re.match(regex, endday):
+        click.echo("INVALID end date - please use YYYY-MM-DD format")
+        sys.exit(1)
+
+    if week != "":
+        day = date.today().strftime("%Y-%m-%d")
+        dt = datetime.strptime(day, "%Y-%m-%d")
+        _startday = dt - timedelta(days=dt.weekday()) + timedelta(weeks=int(week))
+        _endday = _startday + timedelta(days=6)
+        startday = _startday.strftime("%Y-%m-%d")
+        endday = _endday.strftime("%Y-%m-%d")
+
+    if verbose:
+        logger.setLevel(logging.DEBUG)
+        logger.debug("enabling DEBUG mode")
+    ctx.obj = {
+        "options": {},
+        "startday": startday,
+        "endday": endday
+    }
+
+
+@cli.command(name="delete",aliases=["d", "del", "rm", "remove"])
+@click.argument("timecard", required=False)
+@click.pass_context
+@catch_exceptions
+def delete(ctx, timecard):
+
+    if not timecard:
+        rs = te.list_timecard(False, ctx.obj["startday"], ctx.obj["endday"])
+        i = 0
+        nice_tn = []
+        click.echo("Please choose which timecard:")
+        for timecard_rs in rs:
+            click.echo("[{}] {} - {}".format(i,
+                                             timecard_rs["Name"],
+                                             timecard_rs.get(
+                                                 "pse__Project_Name__c", "")
+                                             )
+                       )
+            nice_tn.append(
+                {"Id": timecard_rs["Id"], "Name": timecard_rs["Name"]})
+            i += 1
+        select_tmc = input("Selection: ")
+        timecard_id = nice_tn[int(select_tmc)]["Id"]
+        timecard_name = nice_tn[int(select_tmc)]["Name"]
+    else:
+        timecard_id = te.get_timecard_id(timecard)
+        timecard_name = timecard
+
+    if click.confirm(
+            "Do you want to delete the timecard: {} {}?".format(
+                timecard_name,
+                timecard_rs.get("pse__Project_Name__c", "")
+            ),
+            abort=True):
+        te.delete_time_entry(timecard_id)
+        logger.info("timecard {} deleted".format(timecard_name))
+
+
+@cli.command(name="submit", aliases=["s", "send"])
+@click.option(
+    "-f", "--force", default=False, is_flag=True, help="confirm all question")
+
+@click.pass_context
+@catch_exceptions
+def submit(ctx, force):
+    rs = te.list_timecard(False, ctx.obj["startday"], ctx.obj["endday"])
+    tc_ids = []
+    for timecard_rs in rs:
+        click.echo("{} - {}".format(timecard_rs["Name"],
+                                    timecard_rs.get(
+                                            "pse__Project_Name__c", "")
+                                        )
+                )
+        tc_ids.append(timecard_rs)
+
+    if force == False:
+            click.confirm("Do you want to submit all timecard ?", default=True, abort=True)
+            click.echo()
+
+    for tc in tc_ids:
+        te.submit_time_entry(tc["Id"])
+        logger.info("timecard {} submitted".format(tc["Name"]))
+
+
+@cli.command(name="list", aliases=["ls", "lst", "l"])
+@click.option("--details/--no-details", default=False)
+@click.option(
+    "--style",
+    type=click.Choice(["plain", "simple", "github", "grid", "fancy_grid", "pipe", "orgtbl", "jira", "presto", "json"]),
+    default="grid",
+    help="table style")
+@click.pass_context
+@catch_exceptions
+def list(ctx, details, style):
+    rs = te.list_timecard(details, ctx.obj["startday"], ctx.obj["endday"])
+    if style == "json":
+        click.echo(json.dumps(rs, indent=4))
+    else:
+        hc = HoursCounter(rs)
+        click.echo(tabulate(hc.report, headers="keys", tablefmt=style, stralign="center", ))
+
+
+
+@cli.command(name="add", aliases=["a", "ad"])
+@click.option(
+    "-p", "--project", default="", help="Project Name")
+@click.option(
+    "-n", "--notes", default="Business as usual", help="Notes to add")
+@click.option(
+    "-t", "--hours", default=0, help="hour/s to add")
+@click.option(
+    "--weekday",
+    type=click.Choice(["Monday", "Tuesday", "Wednesday",
+                       "Thursday", "Friday", "Saturday", "Sunday"]),
+    default=date.today().strftime("%A"),
+    help="Weekday to add")
+@click.option(
+    "-w",
+    type=click.Choice(["", "1", "2", "3", "4", "5", "6", "7"]),
+    default="",
+    help="INT Weekday to add")
+@click.option(
+    "-f", "--file", default="", help="YAML file containing timesheet data")
+@click.pass_context
+@catch_exceptions
+def add(ctx, project, notes, hours, weekday, w, file):
+    # hack to let the option call the verb recursively
+    if file != "":
+        click.echo(f"Parsing timesheet file {file}...")
+        with open(file, 'r') as stream:
+            bulk_data = yaml.safe_load(stream)
+
+        click.echo(bulk_data)
+        for day, work in bulk_data.items():
+            click.echo(f"Adding entries for {day}...")
+            for task, meta in work.items():
+                notes = meta['notes'] if 'notes' in meta else ''
+                process_row(ctx, task, notes, meta['hours'], day, '', '')
+    else:
+        process_row(ctx, project, notes, hours, weekday, w, file)

--- a/test/sample.yaml
+++ b/test/sample.yaml
@@ -1,15 +1,15 @@
 ---
 Monday:
-  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+  PX9999 - [REMOTE] - Remote work:
     hours: 8
 Tuesday:
-  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+  PX9999 - [ONSITE] - On-site work:
     hours: 8
 Wednesday:
-  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+  PX9999 - [ONSITE] - On-site work:
     hours: 8
 Thursday:
-  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+  PX9999 - [REMOTE] - Remote work:
     hours: 8
 Friday:
   Personal Development:

--- a/test/sample.yaml
+++ b/test/sample.yaml
@@ -1,0 +1,19 @@
+---
+Monday:
+  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+    hours: 8
+Tuesday:
+  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+    hours: 8
+Wednesday:
+  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+    hours: 8
+Thursday:
+  PX1601 - [REMOTE] - NBIM Post Migration Ext June  - Chris Cunningham:
+    hours: 8
+Friday:
+  Personal Development:
+    hours: 4
+    notes: Working on Giulio's SalesForce CLI tool
+  Team Management:
+    hours: 4


### PR DESCRIPTION
Add support for providing a YAML file with timesheet configuration in it. This requires that the add() function be split, so that if YAML is provided the lookup logic can be iterated over