### PR TITLE
New timecard when partial week already submitted

### DIFF
--- a/salesforce_timecard/core.py
+++ b/salesforce_timecard/core.py
@@ -201,7 +201,8 @@ class TimecardEntry(object):
                 pse__Start_Date__c = {} and pse__End_Date__c = {} and
                 pse__Resource__c = '{}' and 
                 pse__Assignment__c = '{}'  and 
-                pse__Project__c = '{}' 
+                pse__Project__c = '{}' and
+                pse__Status__c not in ('Submitted', 'Approved')
                 '''.format(
                 self.start.strftime("%Y-%m-%d"),
                 self.end.strftime("%Y-%m-%d"),
@@ -217,7 +218,8 @@ class TimecardEntry(object):
                 where 
                 pse__Start_Date__c = {} and pse__End_Date__c = {} and
                 pse__Resource__c = '{}' and 
-                pse__Project__c = '{}' 
+                pse__Project__c = '{}' and
+                pse__Status__c not in ('Submitted', 'Approved')
                 '''.format(
                 self.start.strftime("%Y-%m-%d"),
                 self.end.strftime("%Y-%m-%d"),


### PR DESCRIPTION
Create a new timecard when a timecard covering partial week has already been submitted.

Otherwise you get error like

```
[2019-10-02 21:19:53,360][ERROR] failed on update
[2019-10-02 21:19:53,360][ERROR] Malformed request https://cccccccccc.my.salesforce.com/services/data/v38.0/sobjects/pse__Timecard_Header__c/a8D0J000000071DUAQ. Response content: [{'message': 'Timecard Header may not be changed after it is Billed or Invoiced.', 'errorCode': 'FIELD_CUSTOM_VALIDATION_EXCEPTION', 'fields': []}]
[2019-10-02 21:19:53,360][ERROR] 1
```